### PR TITLE
Various updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ dnsseed: dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o
 	g++ -pthread $(LDFLAGS) -o dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o -lcrypto
 
 %.o: %.cpp bitcoin.h netbase.h protocol.h db.h serialize.h uint256.h util.h
-	g++ -pthread $(CXXFLAGS) -Wno-invalid-offsetof -c -o $@ $<
+	g++ -std=c++11 -pthread $(CXXFLAGS) -Wall -Wno-unused -Wno-sign-compare -Wno-reorder -Wno-comment -c -o $@ $<
 
 dns.o: dns.c
-	gcc -pthread -std=c99 $(CXXFLAGS) dns.c -c -o dns.o
+	gcc -pthread -std=c99 $(CXXFLAGS) dns.c -Wall -c -o dns.o
 
 %.o: %.cpp

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ dns.o: dns.c
 	gcc -pthread -std=c99 $(CXXFLAGS) dns.c -Wall -c -o dns.o
 
 %.o: %.cpp
+
+clean:
+	$(RM) dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 CXXFLAGS = -O3 -g0 -march=native
 LDFLAGS = $(CXXFLAGS)
 
-dnsseed: dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o
-	g++ -pthread $(LDFLAGS) -o dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o -lcrypto
+dnsseed: dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o logging.o
+	g++ -pthread $(LDFLAGS) -o dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o logging.o -lcrypto
 
-%.o: %.cpp bitcoin.h netbase.h protocol.h db.h serialize.h uint256.h util.h
+%.o: %.cpp bitcoin.h netbase.h protocol.h db.h serialize.h uint256.h util.h logging.h
 	g++ -std=c++11 -pthread $(CXXFLAGS) -Wall -Wno-unused -Wno-sign-compare -Wno-reorder -Wno-comment -c -o $@ $<
 
 dns.o: dns.c
@@ -13,4 +13,4 @@ dns.o: dns.c
 %.o: %.cpp
 
 clean:
-	$(RM) dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o
+	$(RM) dnsseed dns.o bitcoin.o netbase.o protocol.o db.o main.o util.o logging.o

--- a/README
+++ b/README
@@ -1,14 +1,14 @@
-bitcoin-seeder
+zcash-seeder
 ==============
 
-Bitcoin-seeder is a crawler for the Bitcoin network, which exposes a list
+zcash-seeder is a crawler for the Zcash network, which exposes a list
 of reliable nodes via a built-in DNS server.
+
+Forked from [bitcoin-seeder](https://github.com/sipa/bitcoin-seeder) by Peter Wuille.
 
 Features:
 * regularly revisits known nodes to check their availability
 * bans nodes after enough failures, or bad behaviour
-* accepts nodes down to v0.3.19 to request new IP addresses from,
-  but only reports good post-v0.3.24 nodes.
 * keeps statistics over (exponential) windows of 2 hours, 8 hours,
   1 day and 1 week, to base decisions on.
 * very low memory (a few tens of megabytes) and cpu requirements.

--- a/README
+++ b/README
@@ -11,8 +11,9 @@ Features:
 * bans nodes after enough failures, or bad behaviour
 * keeps statistics over (exponential) windows of 2 hours, 8 hours,
   1 day and 1 week, to base decisions on.
-* very low memory (a few tens of megabytes) and cpu requirements.
+* very low memory (a few tens of megabytes) and CPU requirements.
 * crawlers run in parallel (by default 24 threads simultaneously).
+* writes a log of nodes discovered to dnsseed.log
 
 REQUIREMENTS
 ------------
@@ -22,7 +23,7 @@ $ sudo apt-get install build-essential libboost-all-dev libssl-dev
 USAGE
 -----
 
-Assuming you want to run a dns seed on dnsseed.example.com, you will
+Assuming you want to run a DNS seed on dnsseed.example.com, you will
 need an authorative NS record in example.com's domain record, pointing
 to for example vps.example.com:
 
@@ -40,7 +41,7 @@ e-mail address (with the @ part replaced by .) using -m.
 
 COMPILING
 ---------
-Compiling will require boost and ssl.  On debian systems, these are provided
+Compiling will require boost and ssl.  On Debian systems, these are provided
 by `libboost-dev` and `libssl-dev` respectively.
 
 $ make

--- a/bitcoin.cpp
+++ b/bitcoin.cpp
@@ -36,16 +36,16 @@ class CNode {
     nHeaderStart = vSend.size();
     vSend << CMessageHeader(pszCommand, 0);
     nMessageStart = vSend.size();
-//    printf("%s: SEND %s\n", ToString(you).c_str(), pszCommand); 
+//    printf("%s: SEND %s\n", ToString(you).c_str(), pszCommand);
   }
-  
+
   void AbortMessage() {
     if (nHeaderStart == -1) return;
     vSend.resize(nHeaderStart);
     nHeaderStart = -1;
     nMessageStart = -1;
   }
-  
+
   void EndMessage() {
     if (nHeaderStart == -1) return;
     unsigned int nSize = vSend.size() - nMessageStart;
@@ -60,7 +60,7 @@ class CNode {
     nHeaderStart = -1;
     nMessageStart = -1;
   }
-  
+
   void Send() {
     if (sock == INVALID_SOCKET) return;
     if (vSend.empty()) return;
@@ -72,7 +72,7 @@ class CNode {
       sock = INVALID_SOCKET;
     }
   }
-  
+
   void PushVersion() {
     int64 nTime = time(NULL);
     uint64 nLocalNonce = BITCOIN_SEED_NONCE;
@@ -84,7 +84,7 @@ class CNode {
     vSend << PROTOCOL_VERSION << nLocalServices << nTime << you << me << nLocalNonce << ver << nBestHeight;
     EndMessage();
   }
- 
+
   void GotVersion() {
     // printf("\n%s: version %i\n", ToString(you).c_str(), nVersion);
     if (vAddr) {
@@ -111,7 +111,7 @@ class CNode {
         vRecv >> strSubVer;
       if (nVersion >= 209 && !vRecv.empty())
         vRecv >> nStartingHeight;
-      
+
       if (nVersion >= 209) {
         BeginMessage("verack");
         EndMessage();
@@ -123,13 +123,13 @@ class CNode {
       }
       return false;
     }
-    
+
     if (strCommand == "verack") {
       this->vRecv.SetVersion(min(nVersion, PROTOCOL_VERSION));
       GotVersion();
       return false;
     }
-    
+
     if (strCommand == "addr" && vAddr) {
       vector<CAddress> vAddrNew;
       vRecv >> vAddrNew;
@@ -152,10 +152,10 @@ class CNode {
       }
       return false;
     }
-    
+
     return false;
   }
-  
+
   bool ProcessMessages() {
     if (vRecv.empty()) return false;
     do {
@@ -171,16 +171,16 @@ class CNode {
       vector<char> vHeaderSave(vRecv.begin(), vRecv.begin() + nHeaderSize);
       CMessageHeader hdr;
       vRecv >> hdr;
-      if (!hdr.IsValid()) { 
+      if (!hdr.IsValid()) {
         // printf("%s: BAD (invalid header)\n", ToString(you).c_str());
         ban = 100000; return true;
       }
       string strCommand = hdr.GetCommand();
       unsigned int nMessageSize = hdr.nMessageSize;
-      if (nMessageSize > MAX_SIZE) { 
+      if (nMessageSize > MAX_SIZE) {
         // printf("%s: BAD (message too large)\n", ToString(you).c_str());
         ban = 100000;
-        return true; 
+        return true;
       }
       if (nMessageSize > vRecv.size()) {
         vRecv.insert(vRecv.begin(), vHeaderSave.begin(), vHeaderSave.end());
@@ -200,7 +200,7 @@ class CNode {
     } while(1);
     return false;
   }
-  
+
 public:
   CNode(const CService& ip, vector<CAddress>* vAddrIn) : you(ip), nHeaderStart(-1), nMessageStart(-1), vAddr(vAddrIn), ban(0), doneAfter(0), nVersion(0) {
     vSend.SetType(SER_NETWORK);
@@ -258,19 +258,19 @@ public:
     sock = INVALID_SOCKET;
     return (ban == 0) && res;
   }
-  
+
   int GetBan() {
     return ban;
   }
-  
+
   int GetClientVersion() {
     return nVersion;
   }
-  
+
   std::string GetClientSubVersion() {
     return strSubVer;
   }
-  
+
   int GetStartingHeight() {
     return nStartingHeight;
   }

--- a/db.h
+++ b/db.h
@@ -40,7 +40,7 @@ public:
     count = count * f + 1;
     weight = weight * f + (1.0-f);
   }
-  
+
   IMPLEMENT_SERIALIZE (
     READWRITE(weight);
     READWRITE(count);
@@ -83,7 +83,7 @@ private:
   std::string clientSubVersion;
 public:
   CAddrInfo() : services(0), lastTry(0), ourLastTry(0), ourLastSuccess(0), ignoreTill(0), clientVersion(0), blocks(0), total(0), success(0) {}
-  
+
   CAddrReport GetReport() const {
     CAddrReport ret;
     ret.ip = ip;
@@ -100,7 +100,7 @@ public:
     ret.services = services;
     return ret;
   }
-  
+
   bool IsGood() const {
     if (ip.GetPort() != GetDefaultPort()) return false;
     if (!(services & NODE_NETWORK)) return false;
@@ -115,7 +115,7 @@ public:
     if (stat1D.reliability > 0.55 && stat1D.count > 8) return true;
     if (stat1W.reliability > 0.45 && stat1W.count > 16) return true;
     if (stat1M.reliability > 0.35 && stat1M.count > 32) return true;
-    
+
     return false;
   }
   int GetBanTime() const {
@@ -134,11 +134,11 @@ public:
     if (stat8H.reliability - stat8H.weight + 1.0 < 0.08 && stat8H.count > 2)  { return 2*3600; }
     return 0;
   }
-  
+
   void Update(bool good);
-  
+
   friend class CAddrDb;
-  
+
   IMPLEMENT_SERIALIZE (
     unsigned char version = 4;
     READWRITE(version);
@@ -198,7 +198,7 @@ struct CServiceResult {
 //                       /       |                     \
 //               tracked nodes   (b) unknown nodes   (e) active nodes
 //              /           \
-//     (d) good nodes   (c) non-good nodes 
+//     (d) good nodes   (c) non-good nodes
 
 class CAddrDb {
 private:
@@ -210,7 +210,7 @@ private:
   std::set<int> unkId; // set of nodes not yet tried (b)
   std::set<int> goodId; // set of good nodes  (d, good e)
   int nDirty;
-  
+
 protected:
   // internal routines that assume proper locks are acquired
   void Add_(const CAddress &addr, bool force);   // add an address
@@ -241,7 +241,7 @@ public:
            (*it).second.ignoreTill = 0;
       }
   }
-  
+
   std::vector<CAddrReport> GetAll() {
     std::vector<CAddrReport> ret;
     SHARED_CRITICAL_BLOCK(cs) {
@@ -254,7 +254,7 @@ public:
     }
     return ret;
   }
-  
+
   // serialization code
   // format:
   //   nVersion (0 for now)

--- a/logging.cpp
+++ b/logging.cpp
@@ -32,7 +32,7 @@ void Log::thread_handle(){
       this->run_cv.wait(flck);
     }
     shared_ptr<LogMsg> msg = msg_queue.front();
-    fout << *msg; // << std::endl;
+    fout << *msg;
     msg_queue.pop();
   }
 }

--- a/logging.cpp
+++ b/logging.cpp
@@ -1,0 +1,89 @@
+#include "logging.h"
+
+#include <sys/stat.h>
+#include <stdarg.h>
+
+using namespace std;
+
+Log::LogMsg::LogMsg(std::string& msg){
+  this->message = msg;
+}
+
+ostream& operator<<(ostream& logstream, const Log::LogMsg& msg){
+  return logstream << msg.message;
+}
+
+Log::Log(): msg_queue(), trans_mutex(), run_cv(){
+  is_open = false;
+}
+
+Log& Log::init(){
+  static Log instance;
+  return instance;
+}
+
+void Log::thread_handle(){
+  while(1){
+    unique_lock<mutex> flck(this->trans_mutex);
+    while(msg_queue.empty()){
+      if (!is_open){
+        return;
+      }
+      this->run_cv.wait(flck);
+    }
+    shared_ptr<LogMsg> msg = msg_queue.front();
+    fout << *msg; // << std::endl;
+    msg_queue.pop();
+  }
+}
+
+void Log::open(){
+  struct stat buf;
+  fout.open(logfile, ofstream::out | ios::app);
+  if(fout.fail()){
+    throw std::ios_base::failure("Error opening log file.");
+  }
+  is_open = true;
+  thread t(&Log::thread_handle, this);
+  exec_thread.swap(t);
+}
+
+void Log::write(const std::string& format, ...){
+  char buffer[format.size() + 1];
+  va_list args;
+  va_start(args, format);
+  vsprintf(buffer, format.c_str(), args);
+  std::string message(buffer);
+  //printf("%s\n", message.c_str());
+  shared_ptr<LogMsg> msg = make_shared<LogMsg>(message);
+  unique_lock<mutex> flck(trans_mutex);
+  if(!is_open){
+    flck.unlock();
+    throw std::runtime_error("The logger received a message but the log file is not open.");
+  }
+  bool queue_empty = msg_queue.empty();
+  msg_queue.push(msg);
+  if(queue_empty){
+    run_cv.notify_one();
+  }
+}
+
+void Log::close(){
+  unique_lock<mutex> flck(trans_mutex);
+  if(!is_open)
+    return;
+  is_open = false;
+  flck.unlock();
+  run_cv.notify_one();
+  exec_thread.join();
+  fout.close();
+}
+
+extern std::string currentTimestamp() {
+  const unsigned int time_size = 256;
+  char time_buffer[time_size];
+  time_t now = time(NULL);
+  struct tm *tmp = localtime(&now);
+  strftime(time_buffer, time_size, "[%m/%d/%y %H:%M:%S]", tmp);
+  return std::string(time_buffer);
+}

--- a/logging.cpp
+++ b/logging.cpp
@@ -84,6 +84,6 @@ extern std::string currentTimestamp() {
   char time_buffer[time_size];
   time_t now = time(NULL);
   struct tm *tmp = localtime(&now);
-  strftime(time_buffer, time_size, "[%m/%d/%y %H:%M:%S]", tmp);
+  strftime(time_buffer, time_size, "[%Y-%m-%d %H:%M:%S]", tmp);
   return std::string(time_buffer);
 }

--- a/logging.h
+++ b/logging.h
@@ -22,24 +22,24 @@ class Log {
     private:
         bool is_open;
         std::ofstream fout;
-	      std::mutex trans_mutex;
-	      std::condition_variable run_cv;
-	      std::thread exec_thread;
+        std::mutex trans_mutex;
+        std::condition_variable run_cv;
+        std::thread exec_thread;
 
-	      class LogMsg {
-	          public:
-	              LogMsg(std::string&);
-		            friend std::ostream& operator<<(std::ostream&, const LogMsg&);
-	          private:
-	               std::string message;
-	      };
+        class LogMsg {
+            public:
+                LogMsg(std::string&);
+                friend std::ostream& operator<<(std::ostream&, const LogMsg&);
+	    private:
+                std::string message;
+        };
 
         std::queue<std::shared_ptr<LogMsg>> msg_queue;
-	      Log();
-	      Log(Log const&){};
-	      Log& operator=(Log const&);
-	      void thread_handle();
-	      friend std::ostream& operator<<(std::ostream&, const LogMsg&);
+        Log();
+        Log(Log const&){};
+        Log& operator=(Log const&);
+        void thread_handle();
+        friend std::ostream& operator<<(std::ostream&, const LogMsg&);
 };
 
 #endif

--- a/logging.h
+++ b/logging.h
@@ -1,0 +1,45 @@
+#ifndef _LOGGING_H_
+#define _LOGGING_H_ 1
+
+#include <fstream>
+#include <queue>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+#define LOGFILE "dnsseed.log"
+
+static const char* logfile = LOGFILE;
+std::string currentTimestamp();
+
+class Log {
+    public:
+        static Log& init();
+        void open();
+        void write(const std::string& format, ...);
+        void close();
+
+    private:
+        bool is_open;
+        std::ofstream fout;
+	      std::mutex trans_mutex;
+	      std::condition_variable run_cv;
+	      std::thread exec_thread;
+
+	      class LogMsg {
+	          public:
+	              LogMsg(std::string&);
+		            friend std::ostream& operator<<(std::ostream&, const LogMsg&);
+	          private:
+	               std::string message;
+	      };
+
+        std::queue<std::shared_ptr<LogMsg>> msg_queue;
+	      Log();
+	      Log(Log const&){};
+	      Log& operator=(Log const&);
+	      void thread_handle();
+	      friend std::ostream& operator<<(std::ostream&, const LogMsg&);
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -217,7 +217,7 @@ public:
         nets[NET_IPV6] = true;
     }
     time_t now = time(NULL);
-    FlagSpecificData thisflag = perflag[requestedFlags];
+    FlagSpecificData& thisflag = perflag[requestedFlags];
     thisflag.cacheHits++;
     if (force || thisflag.cacheHits * 400 > (thisflag.cache.size()*thisflag.cache.size()) || (thisflag.cacheHits*thisflag.cacheHits * 20 > thisflag.cache.size() && (now - thisflag.cacheTime > 5))) {
       set<CNetAddr> ips;

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
+#include <atomic>
 
 #include "bitcoin.h"
 #include "db.h"
@@ -188,19 +189,25 @@ extern "C" void* ThreadCrawler(void* data) {
     db.ResultMany(ips);
     db.Add(addr);
   } while(1);
+  return nullptr;
 }
 
 extern "C" int GetIPList(void *thread, char *requestedHostname, addr_t *addr, int max, int ipv4, int ipv6);
 
 class CDnsThread {
 public:
+  struct FlagSpecificData {
+      int nIPv4, nIPv6;
+      std::vector<addr_t> cache;
+      time_t cacheTime;
+      unsigned int cacheHits;
+      FlagSpecificData() : nIPv4(0), nIPv6(0), cacheTime(0), cacheHits(0) {}
+  };
+
   dns_opt_t dns_opt; // must be first
   const int id;
-  std::map<uint64_t, vector<addr_t> > cache;
-  int nIPv4, nIPv6;
-  std::map<uint64_t, time_t> cacheTime;
-  unsigned int cacheHits;
-  uint64_t dbQueries;
+  std::map<uint64_t, FlagSpecificData> perflag;
+  std::atomic<uint64_t> dbQueries;
   std::set<uint64_t> filterWhitelist;
 
   void cacheHit(uint64_t requestedFlags, bool force = false) {
@@ -210,15 +217,16 @@ public:
         nets[NET_IPV6] = true;
     }
     time_t now = time(NULL);
-    cacheHits++;
-    if (force || cacheHits > (cache[requestedFlags].size()*cache[requestedFlags].size()/400) || (cacheHits*cacheHits > cache[requestedFlags].size() / 20 && (now - cacheTime[requestedFlags] > 5))) {
+    FlagSpecificData thisflag = perflag[requestedFlags];
+    thisflag.cacheHits++;
+    if (force || thisflag.cacheHits * 400 > (thisflag.cache.size()*thisflag.cache.size()) || (thisflag.cacheHits*thisflag.cacheHits * 20 > thisflag.cache.size() && (now - thisflag.cacheTime > 5))) {
       set<CNetAddr> ips;
       db.GetIPs(ips, requestedFlags, 1000, nets);
       dbQueries++;
-      cache[requestedFlags].clear();
-      nIPv4 = 0;
-      nIPv6 = 0;
-      cache[requestedFlags].reserve(ips.size());
+      thisflag.cache.clear();
+      thisflag.nIPv4 = 0;
+      thisflag.nIPv6 = 0;
+      thisflag.cache.reserve(ips.size());
       for (set<CNetAddr>::iterator it = ips.begin(); it != ips.end(); it++) {
         struct in_addr addr;
         struct in6_addr addr6;
@@ -226,18 +234,18 @@ public:
           addr_t a;
           a.v = 4;
           memcpy(&a.data.v4, &addr, 4);
-          cache[requestedFlags].push_back(a);
-          nIPv4++;
+          thisflag.cache.push_back(a);
+          thisflag.nIPv4++;
         } else if ((*it).GetIn6Addr(&addr6)) {
           addr_t a;
           a.v = 6;
           memcpy(&a.data.v6, &addr6, 16);
-          cache[requestedFlags].push_back(a);
-          nIPv6++;
+          thisflag.cache.push_back(a);
+          thisflag.nIPv6++;
         }
       }
-      cacheHits = 0;
-      cacheTime[requestedFlags] = now;
+      thisflag.cacheHits = 0;
+      thisflag.cacheTime = now;
     }
   }
 
@@ -250,12 +258,8 @@ public:
     dns_opt.cb = GetIPList;
     dns_opt.port = opts->nPort;
     dns_opt.nRequests = 0;
-    cache.clear();
-    cacheTime.clear();
-    cacheHits = 0;
     dbQueries = 0;
-    nIPv4 = 0;
-    nIPv6 = 0;
+    perflag.clear();
     filterWhitelist = opts->filter_whitelist;
   }
 
@@ -280,8 +284,9 @@ extern "C" int GetIPList(void *data, char *requestedHostname, addr_t* addr, int 
   else if (strcasecmp(requestedHostname, thread->dns_opt.host))
     return 0;
   thread->cacheHit(requestedFlags);
-  unsigned int size = thread->cache[requestedFlags].size();
-  unsigned int maxmax = (ipv4 ? thread->nIPv4 : 0) + (ipv6 ? thread->nIPv6 : 0);
+  auto& thisflag = thread->perflag[requestedFlags];
+  unsigned int size = thisflag.cache.size();
+  unsigned int maxmax = (ipv4 ? thisflag.nIPv4 : 0) + (ipv6 ? thisflag.nIPv6 : 0);
   if (max > size)
     max = size;
   if (max > maxmax)
@@ -290,16 +295,16 @@ extern "C" int GetIPList(void *data, char *requestedHostname, addr_t* addr, int 
   while (i<max) {
     int j = i + (rand() % (size - i));
     do {
-        bool ok = (ipv4 && thread->cache[requestedFlags][j].v == 4) ||
-                  (ipv6 && thread->cache[requestedFlags][j].v == 6);
+        bool ok = (ipv4 && thisflag.cache[j].v == 4) ||
+                  (ipv6 && thisflag.cache[j].v == 6);
         if (ok) break;
         j++;
         if (j==size)
             j=i;
     } while(1);
-    addr[i] = thread->cache[requestedFlags][j];
-    thread->cache[requestedFlags][j] = thread->cache[requestedFlags][i];
-    thread->cache[requestedFlags][i] = addr[i];
+    addr[i] = thisflag.cache[j];
+    thisflag.cache[j] = thisflag.cache[i];
+    thisflag.cache[i] = addr[i];
     i++;
   }
   return max;
@@ -310,6 +315,7 @@ vector<CDnsThread*> dnsThread;
 extern "C" void* ThreadDNS(void* arg) {
   CDnsThread *thread = (CDnsThread*)arg;
   thread->run();
+  return nullptr;
 }
 
 int StatCompare(const CAddrReport& a, const CAddrReport& b) {
@@ -346,7 +352,7 @@ extern "C" void* ThreadDumper(void*) {
       double stat[5]={0,0,0,0,0};
       for (vector<CAddrReport>::const_iterator it = v.begin(); it < v.end(); it++) {
         CAddrReport rep = *it;
-        fprintf(d, "%-47s  %4d  %11"PRId64"  %6.2f%% %6.2f%% %6.2f%% %6.2f%% %6.2f%%  %6i  %08"PRIx64"  %5i \"%s\"\n", rep.ip.ToString().c_str(), (int)rep.fGood, rep.lastSuccess, 100.0*rep.uptime[0], 100.0*rep.uptime[1], 100.0*rep.uptime[2], 100.0*rep.uptime[3], 100.0*rep.uptime[4], rep.blocks, rep.services, rep.clientVersion, rep.clientSubVersion.c_str());
+        fprintf(d, "%-47s  %4d  %11" PRId64 "  %6.2f%% %6.2f%% %6.2f%% %6.2f%% %6.2f%%  %6i  %08" PRIx64 "  %5i \"%s\"\n", rep.ip.ToString().c_str(), (int)rep.fGood, rep.lastSuccess, 100.0*rep.uptime[0], 100.0*rep.uptime[1], 100.0*rep.uptime[2], 100.0*rep.uptime[3], 100.0*rep.uptime[4], rep.blocks, rep.services, rep.clientVersion, rep.clientSubVersion.c_str());
         stat[0] += rep.uptime[0];
         stat[1] += rep.uptime[1];
         stat[2] += rep.uptime[2];
@@ -359,6 +365,7 @@ extern "C" void* ThreadDumper(void*) {
       fclose(ff);
     }
   } while(1);
+  return nullptr;
 }
 
 extern "C" void* ThreadStats(void*) {
@@ -387,6 +394,7 @@ extern "C" void* ThreadStats(void*) {
     printf("%s %i/%i available (%i tried in %is, %i new, %i active), %i banned; %llu DNS requests, %llu db queries", c, stats.nGood, stats.nAvail, stats.nTracked, stats.nAge, stats.nNew, stats.nAvail - stats.nTracked - stats.nNew, stats.nBanned, (unsigned long long)requests, (unsigned long long)queries);
     Sleep(1000);
   } while(1);
+  return nullptr;
 }
 
 static const string mainnet_seeds[] = {"dnsseed.bluematt.me", "bitseed.xf2.org", "dnsseed.bitcoin.dashjr.org", "seed.bitcoin.sipa.be", ""};
@@ -411,6 +419,7 @@ extern "C" void* ThreadSeeder(void*) {
     }
     Sleep(1800000);
   } while(1);
+  return nullptr;
 }
 
 int main(int argc, char **argv) {

--- a/main.cpp
+++ b/main.cpp
@@ -374,7 +374,7 @@ extern "C" void* ThreadStats(void*) {
     char c[256];
     time_t tim = time(NULL);
     struct tm *tmp = localtime(&tim);
-    strftime(c, 256, "[%y-%m-%d %H:%M:%S]", tmp);
+    strftime(c, 256, "[%m/%d/%y %H:%M:%S]", tmp);
     CAddrDbStats stats;
     db.GetStats(stats);
     if (first)

--- a/main.cpp
+++ b/main.cpp
@@ -35,7 +35,7 @@ public:
   CDnsSeedOpts() : nThreads(96), nDnsThreads(4), nPort(53), mbox(NULL), ns(NULL), host(NULL), tor(NULL), fUseTestNet(false), fWipeBan(false), fWipeIgnore(false), ipv4_proxy(NULL), ipv6_proxy(NULL) {}
 
   void ParseCommandLine(int argc, char **argv) {
-    static const char *help = "Bitcoin-seeder\n"
+    static const char *help = "zcash-seeder\n"
                               "Usage: %s -h <host> -n <ns> [-m <mbox>] [-t <threads>] [-p <port>]\n"
                               "\n"
                               "Options:\n"

--- a/main.cpp
+++ b/main.cpp
@@ -394,8 +394,8 @@ extern "C" void* ThreadStats(void*) {
   return nullptr;
 }
 
-static const string mainnet_seeds[] = {"mainnet.z.cash", "dnsseed.str4d.xyz", "dnsseed.znodes.org", ""};
-static const string testnet_seeds[] = {"testnet.z.cash", "explorer.testnet.z.cash", ""};
+static const string mainnet_seeds[] = {"mainnet.z.cash", "dnsseed.str4d.xyz", "dnsseed.znodes.org", "network.zcha.in", "insight.mercerweiss.com", ""};
+static const string testnet_seeds[] = {"testnet.z.cash", "explorer.testnet.z.cash", "faucet.testnet.z.cash", ""};
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {

--- a/uint256.h
+++ b/uint256.h
@@ -322,7 +322,7 @@ public:
         // hex string to uint
         static char phexdigit[256] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,1,2,3,4,5,6,7,8,9,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0 };
         const char* pbegin = psz;
-        while (phexdigit[*psz] || *psz == '0')
+        while (phexdigit[(unsigned char)*psz] || *psz == '0')
             psz++;
         psz--;
         unsigned char* p1 = (unsigned char*)pn;

--- a/uint256.h
+++ b/uint256.h
@@ -1,40 +1,33 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2011 The Bitcoin developers
+// Copyright (c) 2009-2013 The Bitcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
-// file license.txt or http://www.opensource.org/licenses/mit-license.php.
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #ifndef BITCOIN_UINT256_H
 #define BITCOIN_UINT256_H
 
-#include "serialize.h"
-
-#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <string>
+#include <string.h>
 #include <vector>
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
-typedef __int64  int64;
-typedef unsigned __int64  uint64;
-#else
-typedef long long  int64;
-typedef unsigned long long  uint64;
-#endif
-#if defined(_MSC_VER) && _MSC_VER < 1300
-#define for  if (false) ; else for
-#endif
+extern const signed char p_util_hexdigit[256]; // defined in util.cpp
 
+inline signed char HexDigit(char c)
+{
+    return p_util_hexdigit[(unsigned char)c];
+}
 
-inline int Testuint256AdHoc(std::vector<std::string> vArg);
-
-
-
-// We have to keep a separate base class without constructors
-// so the compiler will let us use it in a union
+/** Base class without constructors for uint256 and uint160.
+ * This makes the compiler let you use it in a union.
+ */
 template<unsigned int BITS>
 class base_uint
 {
 protected:
     enum { WIDTH=BITS/32 };
-    unsigned int pn[WIDTH];
+    uint32_t pn[WIDTH];
 public:
 
     bool operator!() const
@@ -62,8 +55,18 @@ public:
         return ret;
     }
 
+    double getdouble() const
+    {
+        double ret = 0.0;
+        double fact = 1.0;
+        for (int i = 0; i < WIDTH; i++) {
+            ret += fact * pn[i];
+            fact *= 4294967296.0;
+        }
+        return ret;
+    }
 
-    base_uint& operator=(uint64 b)
+    base_uint& operator=(uint64_t b)
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
@@ -93,21 +96,14 @@ public:
         return *this;
     }
 
-    base_uint& operator^=(uint64 b)
+    base_uint& operator^=(uint64_t b)
     {
         pn[0] ^= (unsigned int)b;
         pn[1] ^= (unsigned int)(b >> 32);
         return *this;
     }
 
-    base_uint& operator&=(uint64 b)
-    {
-        pn[0] &= (unsigned int)b;
-        pn[1] &= (unsigned int)(b >> 32);
-        return *this;
-    }
-
-    base_uint& operator|=(uint64 b)
+    base_uint& operator|=(uint64_t b)
     {
         pn[0] |= (unsigned int)b;
         pn[1] |= (unsigned int)(b >> 32);
@@ -150,10 +146,10 @@ public:
 
     base_uint& operator+=(const base_uint& b)
     {
-        uint64 carry = 0;
+        uint64_t carry = 0;
         for (int i = 0; i < WIDTH; i++)
         {
-            uint64 n = carry + pn[i] + b.pn[i];
+            uint64_t n = carry + pn[i] + b.pn[i];
             pn[i] = n & 0xffffffff;
             carry = n >> 32;
         }
@@ -166,7 +162,7 @@ public:
         return *this;
     }
 
-    base_uint& operator+=(uint64 b64)
+    base_uint& operator+=(uint64_t b64)
     {
         base_uint b;
         b = b64;
@@ -174,7 +170,7 @@ public:
         return *this;
     }
 
-    base_uint& operator-=(uint64 b64)
+    base_uint& operator-=(uint64_t b64)
     {
         base_uint b;
         b = b64;
@@ -204,7 +200,7 @@ public:
     {
         // prefix operator
         int i = 0;
-        while (--pn[i] == -1 && i < WIDTH-1)
+        while (--pn[i] == (uint32_t)-1 && i < WIDTH-1)
             i++;
         return *this;
     }
@@ -274,7 +270,7 @@ public:
         return true;
     }
 
-    friend inline bool operator==(const base_uint& a, uint64 b)
+    friend inline bool operator==(const base_uint& a, uint64_t b)
     {
         if (a.pn[0] != (unsigned int)b)
             return false;
@@ -291,7 +287,7 @@ public:
         return (!(a == b));
     }
 
-    friend inline bool operator!=(const base_uint& a, uint64 b)
+    friend inline bool operator!=(const base_uint& a, uint64_t b)
     {
         return (!(a == b));
     }
@@ -301,15 +297,14 @@ public:
     std::string GetHex() const
     {
         char psz[sizeof(pn)*2 + 1];
-        for (int i = 0; i < sizeof(pn); i++)
+        for (unsigned int i = 0; i < sizeof(pn); i++)
             sprintf(psz + i*2, "%02x", ((unsigned char*)pn)[sizeof(pn) - i - 1]);
         return std::string(psz, psz + sizeof(pn)*2);
     }
 
     void SetHex(const char* psz)
     {
-        for (int i = 0; i < WIDTH; i++)
-            pn[i] = 0;
+        memset(pn,0,sizeof(pn));
 
         // skip leading spaces
         while (isspace(*psz))
@@ -320,19 +315,18 @@ public:
             psz += 2;
 
         // hex string to uint
-        static char phexdigit[256] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,1,2,3,4,5,6,7,8,9,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0xa,0xb,0xc,0xd,0xe,0xf,0,0,0,0,0,0,0,0,0 };
         const char* pbegin = psz;
-        while (phexdigit[(unsigned char)*psz] || *psz == '0')
+        while (::HexDigit(*psz) != -1)
             psz++;
         psz--;
         unsigned char* p1 = (unsigned char*)pn;
         unsigned char* pend = p1 + WIDTH * 4;
         while (psz >= pbegin && p1 < pend)
         {
-            *p1 = phexdigit[(unsigned char)*psz--];
+            *p1 = ::HexDigit(*psz--);
             if (psz >= pbegin)
             {
-                *p1 |= (phexdigit[(unsigned char)*psz--] << 4);
+                *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
                 p1++;
             }
         }
@@ -358,25 +352,43 @@ public:
         return (unsigned char*)&pn[WIDTH];
     }
 
-    unsigned int size()
+    const unsigned char* begin() const
+    {
+        return (unsigned char*)&pn[0];
+    }
+
+    const unsigned char* end() const
+    {
+        return (unsigned char*)&pn[WIDTH];
+    }
+
+    unsigned int size() const
     {
         return sizeof(pn);
     }
 
+    uint64_t GetLow64() const
+    {
+        assert(WIDTH >= 2);
+        return pn[0] | (uint64_t)pn[1] << 32;
+    }
 
-    unsigned int GetSerializeSize(int nType=0, int nVersion=PROTOCOL_VERSION) const
+//    unsigned int GetSerializeSize(int nType=0, int nVersion=PROTOCOL_VERSION) const
+    unsigned int GetSerializeSize(int nType, int nVersion) const
     {
         return sizeof(pn);
     }
 
     template<typename Stream>
-    void Serialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION) const
+//    void Serialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION) const
+    void Serialize(Stream& s, int nType, int nVersion) const
     {
         s.write((char*)pn, sizeof(pn));
     }
 
     template<typename Stream>
-    void Unserialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION)
+//    void Unserialize(Stream& s, int nType=0, int nVersion=PROTOCOL_VERSION)
+    void Unserialize(Stream& s, int nType, int nVersion)
     {
         s.read((char*)pn, sizeof(pn));
     }
@@ -384,7 +396,6 @@ public:
 
     friend class uint160;
     friend class uint256;
-    friend inline int Testuint256AdHoc(std::vector<std::string> vArg);
 };
 
 typedef base_uint<160> base_uint160;
@@ -404,6 +415,7 @@ typedef base_uint<256> base_uint256;
 // uint160
 //
 
+/** 160-bit unsigned integer */
 class uint160 : public base_uint160
 {
 public:
@@ -428,7 +440,7 @@ public:
         return *this;
     }
 
-    uint160(uint64 b)
+    uint160(uint64_t b)
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
@@ -436,7 +448,7 @@ public:
             pn[i] = 0;
     }
 
-    uint160& operator=(uint64 b)
+    uint160& operator=(uint64_t b)
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
@@ -459,8 +471,8 @@ public:
     }
 };
 
-inline bool operator==(const uint160& a, uint64 b)                           { return (base_uint160)a == b; }
-inline bool operator!=(const uint160& a, uint64 b)                           { return (base_uint160)a != b; }
+inline bool operator==(const uint160& a, uint64_t b)                         { return (base_uint160)a == b; }
+inline bool operator!=(const uint160& a, uint64_t b)                         { return (base_uint160)a != b; }
 inline const uint160 operator<<(const base_uint160& a, unsigned int shift)   { return uint160(a) <<= shift; }
 inline const uint160 operator>>(const base_uint160& a, unsigned int shift)   { return uint160(a) >>= shift; }
 inline const uint160 operator<<(const uint160& a, unsigned int shift)        { return uint160(a) <<= shift; }
@@ -472,44 +484,41 @@ inline const uint160 operator|(const base_uint160& a, const base_uint160& b) { r
 inline const uint160 operator+(const base_uint160& a, const base_uint160& b) { return uint160(a) += b; }
 inline const uint160 operator-(const base_uint160& a, const base_uint160& b) { return uint160(a) -= b; }
 
-inline bool operator<(const base_uint160& a, const uint160& b)          { return (base_uint160)a <  (base_uint160)b; }
-inline bool operator<=(const base_uint160& a, const uint160& b)         { return (base_uint160)a <= (base_uint160)b; }
-inline bool operator>(const base_uint160& a, const uint160& b)          { return (base_uint160)a >  (base_uint160)b; }
-inline bool operator>=(const base_uint160& a, const uint160& b)         { return (base_uint160)a >= (base_uint160)b; }
-inline bool operator==(const base_uint160& a, const uint160& b)         { return (base_uint160)a == (base_uint160)b; }
-inline bool operator!=(const base_uint160& a, const uint160& b)         { return (base_uint160)a != (base_uint160)b; }
-inline const uint160 operator^(const base_uint160& a, const uint160& b) { return (base_uint160)a ^  (base_uint160)b; }
-inline const uint160 operator&(const base_uint160& a, const uint160& b) { return (base_uint160)a &  (base_uint160)b; }
-inline const uint160 operator|(const base_uint160& a, const uint160& b) { return (base_uint160)a |  (base_uint160)b; }
-inline const uint160 operator+(const base_uint160& a, const uint160& b) { return (base_uint160)a +  (base_uint160)b; }
-inline const uint160 operator-(const base_uint160& a, const uint160& b) { return (base_uint160)a -  (base_uint160)b; }
+inline bool operator<(const base_uint160& a, const uint160& b)               { return (base_uint160)a <  (base_uint160)b; }
+inline bool operator<=(const base_uint160& a, const uint160& b)              { return (base_uint160)a <= (base_uint160)b; }
+inline bool operator>(const base_uint160& a, const uint160& b)               { return (base_uint160)a >  (base_uint160)b; }
+inline bool operator>=(const base_uint160& a, const uint160& b)              { return (base_uint160)a >= (base_uint160)b; }
+inline bool operator==(const base_uint160& a, const uint160& b)              { return (base_uint160)a == (base_uint160)b; }
+inline bool operator!=(const base_uint160& a, const uint160& b)              { return (base_uint160)a != (base_uint160)b; }
+inline const uint160 operator^(const base_uint160& a, const uint160& b)      { return (base_uint160)a ^  (base_uint160)b; }
+inline const uint160 operator&(const base_uint160& a, const uint160& b)      { return (base_uint160)a &  (base_uint160)b; }
+inline const uint160 operator|(const base_uint160& a, const uint160& b)      { return (base_uint160)a |  (base_uint160)b; }
+inline const uint160 operator+(const base_uint160& a, const uint160& b)      { return (base_uint160)a +  (base_uint160)b; }
+inline const uint160 operator-(const base_uint160& a, const uint160& b)      { return (base_uint160)a -  (base_uint160)b; }
 
-inline bool operator<(const uint160& a, const base_uint160& b)          { return (base_uint160)a <  (base_uint160)b; }
-inline bool operator<=(const uint160& a, const base_uint160& b)         { return (base_uint160)a <= (base_uint160)b; }
-inline bool operator>(const uint160& a, const base_uint160& b)          { return (base_uint160)a >  (base_uint160)b; }
-inline bool operator>=(const uint160& a, const base_uint160& b)         { return (base_uint160)a >= (base_uint160)b; }
-inline bool operator==(const uint160& a, const base_uint160& b)         { return (base_uint160)a == (base_uint160)b; }
-inline bool operator!=(const uint160& a, const base_uint160& b)         { return (base_uint160)a != (base_uint160)b; }
-inline const uint160 operator^(const uint160& a, const base_uint160& b) { return (base_uint160)a ^  (base_uint160)b; }
-inline const uint160 operator&(const uint160& a, const base_uint160& b) { return (base_uint160)a &  (base_uint160)b; }
-inline const uint160 operator|(const uint160& a, const base_uint160& b) { return (base_uint160)a |  (base_uint160)b; }
-inline const uint160 operator+(const uint160& a, const base_uint160& b) { return (base_uint160)a +  (base_uint160)b; }
-inline const uint160 operator-(const uint160& a, const base_uint160& b) { return (base_uint160)a -  (base_uint160)b; }
+inline bool operator<(const uint160& a, const base_uint160& b)               { return (base_uint160)a <  (base_uint160)b; }
+inline bool operator<=(const uint160& a, const base_uint160& b)              { return (base_uint160)a <= (base_uint160)b; }
+inline bool operator>(const uint160& a, const base_uint160& b)               { return (base_uint160)a >  (base_uint160)b; }
+inline bool operator>=(const uint160& a, const base_uint160& b)              { return (base_uint160)a >= (base_uint160)b; }
+inline bool operator==(const uint160& a, const base_uint160& b)              { return (base_uint160)a == (base_uint160)b; }
+inline bool operator!=(const uint160& a, const base_uint160& b)              { return (base_uint160)a != (base_uint160)b; }
+inline const uint160 operator^(const uint160& a, const base_uint160& b)      { return (base_uint160)a ^  (base_uint160)b; }
+inline const uint160 operator&(const uint160& a, const base_uint160& b)      { return (base_uint160)a &  (base_uint160)b; }
+inline const uint160 operator|(const uint160& a, const base_uint160& b)      { return (base_uint160)a |  (base_uint160)b; }
+inline const uint160 operator+(const uint160& a, const base_uint160& b)      { return (base_uint160)a +  (base_uint160)b; }
+inline const uint160 operator-(const uint160& a, const base_uint160& b)      { return (base_uint160)a -  (base_uint160)b; }
 
-inline bool operator<(const uint160& a, const uint160& b)               { return (base_uint160)a <  (base_uint160)b; }
-inline bool operator<=(const uint160& a, const uint160& b)              { return (base_uint160)a <= (base_uint160)b; }
-inline bool operator>(const uint160& a, const uint160& b)               { return (base_uint160)a >  (base_uint160)b; }
-inline bool operator>=(const uint160& a, const uint160& b)              { return (base_uint160)a >= (base_uint160)b; }
-inline bool operator==(const uint160& a, const uint160& b)              { return (base_uint160)a == (base_uint160)b; }
-inline bool operator!=(const uint160& a, const uint160& b)              { return (base_uint160)a != (base_uint160)b; }
-inline const uint160 operator^(const uint160& a, const uint160& b)      { return (base_uint160)a ^  (base_uint160)b; }
-inline const uint160 operator&(const uint160& a, const uint160& b)      { return (base_uint160)a &  (base_uint160)b; }
-inline const uint160 operator|(const uint160& a, const uint160& b)      { return (base_uint160)a |  (base_uint160)b; }
-inline const uint160 operator+(const uint160& a, const uint160& b)      { return (base_uint160)a +  (base_uint160)b; }
-inline const uint160 operator-(const uint160& a, const uint160& b)      { return (base_uint160)a -  (base_uint160)b; }
-
-
-
+inline bool operator<(const uint160& a, const uint160& b)                    { return (base_uint160)a <  (base_uint160)b; }
+inline bool operator<=(const uint160& a, const uint160& b)                   { return (base_uint160)a <= (base_uint160)b; }
+inline bool operator>(const uint160& a, const uint160& b)                    { return (base_uint160)a >  (base_uint160)b; }
+inline bool operator>=(const uint160& a, const uint160& b)                   { return (base_uint160)a >= (base_uint160)b; }
+inline bool operator==(const uint160& a, const uint160& b)                   { return (base_uint160)a == (base_uint160)b; }
+inline bool operator!=(const uint160& a, const uint160& b)                   { return (base_uint160)a != (base_uint160)b; }
+inline const uint160 operator^(const uint160& a, const uint160& b)           { return (base_uint160)a ^  (base_uint160)b; }
+inline const uint160 operator&(const uint160& a, const uint160& b)           { return (base_uint160)a &  (base_uint160)b; }
+inline const uint160 operator|(const uint160& a, const uint160& b)           { return (base_uint160)a |  (base_uint160)b; }
+inline const uint160 operator+(const uint160& a, const uint160& b)           { return (base_uint160)a +  (base_uint160)b; }
+inline const uint160 operator-(const uint160& a, const uint160& b)           { return (base_uint160)a -  (base_uint160)b; }
 
 
 
@@ -518,6 +527,7 @@ inline const uint160 operator-(const uint160& a, const uint160& b)      { return
 // uint256
 //
 
+/** 256-bit unsigned integer */
 class uint256 : public base_uint256
 {
 public:
@@ -542,7 +552,7 @@ public:
         return *this;
     }
 
-    uint256(uint64 b)
+    uint256(uint64_t b)
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
@@ -550,7 +560,7 @@ public:
             pn[i] = 0;
     }
 
-    uint256& operator=(uint64 b)
+    uint256& operator=(uint64_t b)
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
@@ -573,8 +583,8 @@ public:
     }
 };
 
-inline bool operator==(const uint256& a, uint64 b)                           { return (base_uint256)a == b; }
-inline bool operator!=(const uint256& a, uint64 b)                           { return (base_uint256)a != b; }
+inline bool operator==(const uint256& a, uint64_t b)                          { return (base_uint256)a == b; }
+inline bool operator!=(const uint256& a, uint64_t b)                          { return (base_uint256)a != b; }
 inline const uint256 operator<<(const base_uint256& a, unsigned int shift)   { return uint256(a) <<= shift; }
 inline const uint256 operator>>(const base_uint256& a, unsigned int shift)   { return uint256(a) >>= shift; }
 inline const uint256 operator<<(const uint256& a, unsigned int shift)        { return uint256(a) <<= shift; }
@@ -621,149 +631,5 @@ inline const uint256 operator&(const uint256& a, const uint256& b)      { return
 inline const uint256 operator|(const uint256& a, const uint256& b)      { return (base_uint256)a |  (base_uint256)b; }
 inline const uint256 operator+(const uint256& a, const uint256& b)      { return (base_uint256)a +  (base_uint256)b; }
 inline const uint256 operator-(const uint256& a, const uint256& b)      { return (base_uint256)a -  (base_uint256)b; }
-
-
-
-
-
-
-
-
-
-
-
-
-inline int Testuint256AdHoc(std::vector<std::string> vArg)
-{
-    uint256 g(0);
-
-
-    printf("%s\n", g.ToString().c_str());
-    g--;  printf("g--\n");
-    printf("%s\n", g.ToString().c_str());
-    g--;  printf("g--\n");
-    printf("%s\n", g.ToString().c_str());
-    g++;  printf("g++\n");
-    printf("%s\n", g.ToString().c_str());
-    g++;  printf("g++\n");
-    printf("%s\n", g.ToString().c_str());
-    g++;  printf("g++\n");
-    printf("%s\n", g.ToString().c_str());
-    g++;  printf("g++\n");
-    printf("%s\n", g.ToString().c_str());
-
-
-
-    uint256 a(7);
-    printf("a=7\n");
-    printf("%s\n", a.ToString().c_str());
-
-    uint256 b;
-    printf("b undefined\n");
-    printf("%s\n", b.ToString().c_str());
-    int c = 3;
-
-    a = c;
-    a.pn[3] = 15;
-    printf("%s\n", a.ToString().c_str());
-    uint256 k(c);
-
-    a = 5;
-    a.pn[3] = 15;
-    printf("%s\n", a.ToString().c_str());
-    b = 1;
-    b <<= 52;
-
-    a |= b;
-
-    a ^= 0x500;
-
-    printf("a %s\n", a.ToString().c_str());
-
-    a = a | b | (uint256)0x1000;
-
-
-    printf("a %s\n", a.ToString().c_str());
-    printf("b %s\n", b.ToString().c_str());
-
-    a = 0xfffffffe;
-    a.pn[4] = 9;
-
-    printf("%s\n", a.ToString().c_str());
-    a++;
-    printf("%s\n", a.ToString().c_str());
-    a++;
-    printf("%s\n", a.ToString().c_str());
-    a++;
-    printf("%s\n", a.ToString().c_str());
-    a++;
-    printf("%s\n", a.ToString().c_str());
-
-    a--;
-    printf("%s\n", a.ToString().c_str());
-    a--;
-    printf("%s\n", a.ToString().c_str());
-    a--;
-    printf("%s\n", a.ToString().c_str());
-    uint256 d = a--;
-    printf("%s\n", d.ToString().c_str());
-    printf("%s\n", a.ToString().c_str());
-    a--;
-    printf("%s\n", a.ToString().c_str());
-    a--;
-    printf("%s\n", a.ToString().c_str());
-
-    d = a;
-
-    printf("%s\n", d.ToString().c_str());
-    for (int i = uint256::WIDTH-1; i >= 0; i--) {
-        printf("%08x", d.pn[i]);
-        printf("\n");
-    }
-
-    uint256 neg = d;
-    neg = ~neg;
-    printf("%s\n", neg.ToString().c_str());
-
-
-    uint256 e = uint256("0xABCDEF123abcdef12345678909832180000011111111");
-    printf("\n");
-    printf("%s\n", e.ToString().c_str());
-
-
-    printf("\n");
-    uint256 x1 = uint256("0xABCDEF123abcdef12345678909832180000011111111");
-    uint256 x2;
-    printf("%s\n", x1.ToString().c_str());
-    for (int i = 0; i < 270; i += 4)
-    {
-        x2 = x1 << i;
-        printf("%s\n", x2.ToString().c_str());
-    }
-
-    printf("\n");
-    printf("%s\n", x1.ToString().c_str());
-    for (int i = 0; i < 270; i += 4)
-    {
-        x2 = x1;
-        x2 >>= i;
-        printf("%s\n", x2.ToString().c_str());
-    }
-
-
-    for (int i = 0; i < 100; i++)
-    {
-        uint256 k = (~uint256(0) >> i);
-        printf("%s\n", k.ToString().c_str());
-    }
-
-    for (int i = 0; i < 100; i++)
-    {
-        uint256 k = (~uint256(0) << i);
-        printf("%s\n", k.ToString().c_str());
-    }
-
-    return (0);
-}
 
 #endif

--- a/uint256.h
+++ b/uint256.h
@@ -716,7 +716,10 @@ inline int Testuint256AdHoc(std::vector<std::string> vArg)
     d = a;
 
     printf("%s\n", d.ToString().c_str());
-    for (int i = uint256::WIDTH-1; i >= 0; i--) printf("%08x", d.pn[i]); printf("\n");
+    for (int i = uint256::WIDTH-1; i >= 0; i--) {
+        printf("%08x", d.pn[i]);
+        printf("\n");
+    }
 
     uint256 neg = d;
     neg = ~neg;

--- a/util.h
+++ b/util.h
@@ -35,7 +35,7 @@ protected:
 public:
     explicit CCriticalSection() { pthread_rwlock_init(&mutex, NULL); }
     ~CCriticalSection() { pthread_rwlock_destroy(&mutex); }
-    void Enter(bool fShared = false) { 
+    void Enter(bool fShared = false) {
       if (fShared) {
         pthread_rwlock_rdlock(&mutex);
       } else {


### PR DESCRIPTION
See commit messages and diff for details.

Most important is that you can now keep a log notifying when nodes are added.

Later on the other instances of printf() sprinkled throughout the code (many of them commented out, others which represent legit errors which are lost to STDOUT) may be replaced with logger.write().

Original motivation: the status message printed during the main loop contains binary data, which makes it totally useless to see what's going on with this service using journalctl/systemd.