### PR TITLE
Heartwood updates

### DIFF
--- a/db.h
+++ b/db.h
@@ -12,7 +12,7 @@
 
 #define MIN_RETRY 1000
 
-#define REQUIRE_VERSION 170009
+#define REQUIRE_VERSION 170011
 
 static inline int GetRequireHeight(const bool testnet = fTestNet)
 {

--- a/main.cpp
+++ b/main.cpp
@@ -446,10 +446,10 @@ int main(int argc, char **argv) {
   bool fDNS = true;
   if (opts.fUseTestNet) {
       printf("Using testnet.\n");
-      pchMessageStart[0] = 0xFA;
-      pchMessageStart[1] = 0x1A;
-      pchMessageStart[2] = 0x24;
-      pchMessageStart[3] = 0xB6;
+      pchMessageStart[0] = 0xfa;
+      pchMessageStart[1] = 0x1a;
+      pchMessageStart[2] = 0xf9;
+      pchMessageStart[3] = 0xbf;
       seeds = testnet_seeds;
       fTestNet = true;
   }

--- a/serialize.h
+++ b/serialize.h
@@ -60,7 +60,7 @@ class CDataStream;
 class CAutoFile;
 static const unsigned int MAX_SIZE = 0x02000000;
 
-static const int PROTOCOL_VERSION = 170009;
+static const int PROTOCOL_VERSION = 170011;
 
 // Used to bypass the rule against non-const reference to temporary
 // where it makes sense with wrappers such as CFlatData or CTxDB


### PR DESCRIPTION
This is already live in production, but for completeness we are creating this PR.

During NUs, we need to ensure the `PROTOCOL_VERSION` is consistent with the spec.

There is a block in main.cpp that is specific for testnet. This also needs to be consistent with respective zcash pchMessageStart for testnet.